### PR TITLE
fix: allow null return from getTemplateDefinition()

### DIFF
--- a/Template/DataCollectorSmartyParser.php
+++ b/Template/DataCollectorSmartyParser.php
@@ -105,7 +105,7 @@ class DataCollectorSmartyParser extends \Smarty implements ParserInterface
         $this->smartyParser->setTemplateDefinition($templateDefinition, $fallbackToDefaultTemplate);
     }
 
-    public function getTemplateDefinition($webAssetTemplateName = false): TemplateDefinition
+    public function getTemplateDefinition($webAssetTemplateName = false): ?TemplateDefinition
     {
         return $this->smartyParser->getTemplateDefinition();
     }

--- a/Template/SmartyParser.php
+++ b/Template/SmartyParser.php
@@ -321,11 +321,13 @@ class SmartyParser extends \Smarty implements ParserInterface
      *
      * @param bool|string $webAssetTemplateName false to use the current template path, or a template name to
      *                                          load assets from this template instead of the current one
-     *
-     * @return TemplateDefinition
      */
-    public function getTemplateDefinition($webAssetTemplateName = false): TemplateDefinition
+    public function getTemplateDefinition($webAssetTemplateName = false): ?TemplateDefinition
     {
+        if (null === $this->templateDefinition) {
+            return null;
+        }
+
         // Deep clone of template definition. We could change the template descriptor of template definition,
         // and we don't want to change the current template definition.
 


### PR DESCRIPTION
## Summary

- Align `SmartyParser::getTemplateDefinition()` and `DataCollectorSmartyParser::getTemplateDefinition()` return type with `ParserInterface` (nullable).
- Add a `null` guard in `SmartyParser` before the deep-clone (`unserialize(serialize())`).

## Why

`BaseAdminController::getParser()` calls `$parser->getTemplateDefinition()` **before** `setTemplateDefinition()` is invoked. With a strict non-nullable return type, the call throws a `TypeError` whenever the parser has not yet been hydrated. This blocks the new Twig back-office (`thelia/thelia` `feat/backoffice-twig`, S7 vertical slice) where the Twig parser is preferred over Smarty.

A matching fix on `Thelia\Core\Template\ParserInterface::getTemplateDefinition()` and `ParserTemplateTrait::getTemplateDefinition()` is being applied in `thelia/thelia` (commit `ffc4d12d9` on `feat/backoffice-twig`). This PR aligns the Smarty side so the back-office Twig install (`bin/install --backoffice_theme=default-twig`) keeps working after `composer install`.

## Test plan

- [ ] `composer install` on `thelia/thelia` `feat/backoffice-twig` no longer overrides the local patch.
- [ ] `curl /admin/login` under `--backoffice_theme=default-twig` returns 200 with Twig-rendered output.
- [ ] Playwright back-office baseline (23 specs) stays green under `--backoffice_theme=default`.